### PR TITLE
Fix: nav underline not clearing on route change (#142)

### DIFF
--- a/site/gatsby-browser.js
+++ b/site/gatsby-browser.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import './src/styles/fonts.css';
 import './src/styles/global.css';
 import './src/styles/prismjs.css';
@@ -6,3 +8,12 @@ import './src/styles/header.css';
 import './src/styles/footer.css';
 import './src/styles/hero.css';
 import './src/styles/card.css';
+
+import Layout from './src/components/layout';
+
+// Keep Layout (and its Header/nav) mounted as a single persistent element
+// across page navigations, so the nav underline can animate between
+// routes instead of being torn down and recreated on every click.
+export const wrapPageElement = ({ element, props }) => (
+  <Layout location={props.location}>{element}</Layout>
+);

--- a/site/gatsby-ssr.js
+++ b/site/gatsby-ssr.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+import Layout from './src/components/layout';
+
+// Mirrors gatsby-browser.js so server-rendered markup matches what the
+// client hydrates into (Layout wrapping the page, not each page wrapping
+// its own Layout).
+export const wrapPageElement = ({ element, props }) => (
+  <Layout location={props.location}>{element}</Layout>
+);

--- a/site/src/components/header.js
+++ b/site/src/components/header.js
@@ -2,37 +2,34 @@ import React from 'react';
 import { Link } from 'gatsby';
 import { StaticImage } from 'gatsby-plugin-image';
 
-const Header = ({ location, links }) => {
-  function menuLink(text) {
-    const path = links[text];
-    const classname = location.pathname?.includes(path)
-      ? 'nav-link-current'
-      : 'nav-link';
+const isActive = (location, path) =>
+  path === '/' ? location.pathname === '/' : location.pathname?.includes(path);
 
-    return (
-      <li className={classname} key={text}>
-        <Link to={path}>{text}</Link>
-      </li>
-    );
-  }
-
-  return (
-    <div className="content">
-      <h1 className="logo">
-        <Link className="logo-link" to={`//morganstanley.github.io`}>
-          <StaticImage
-            width={267}
-            src="../images/logo-black.png"
-            alt="Morgan Stanley Logo"
-            placeholder="none"
-          />
-        </Link>
-      </h1>
-      <div className="header-nav">
-        <ul>{Object.keys(links).map(menuLink)}</ul>
-      </div>
+const Header = ({ location, links }) => (
+  <div className="content">
+    <h1 className="logo">
+      <Link className="logo-link" to={`//morganstanley.github.io`}>
+        <StaticImage
+          width={267}
+          src="../images/logo-black.png"
+          alt="Morgan Stanley Logo"
+          placeholder="none"
+        />
+      </Link>
+    </h1>
+    <div className="header-nav">
+      <ul>
+        {Object.entries(links).map(([text, path]) => (
+          <li
+            className={isActive(location, path) ? 'nav-link-current' : 'nav-link'}
+            key={text}
+          >
+            <Link to={path}>{text}</Link>
+          </li>
+        ))}
+      </ul>
     </div>
-  );
-};
+  </div>
+);
 
 export default Header;

--- a/site/src/pages/404.js
+++ b/site/src/pages/404.js
@@ -2,18 +2,15 @@ import React from 'react';
 import { graphql } from 'gatsby';
 
 import Hero from '../components/hero';
-import Layout from '../components/layout';
 import PageHead from '../components/page-head';
 
-const NotFoundPage = ({ data, location }) => {
+const NotFoundPage = () => {
   return (
-    <Layout data={data} location={location}>
-      <div className="main home-main">
-        <Hero title="404 Not Found">
-          What you are looking for is either no longer here or has moved.
-        </Hero>
-      </div>
-    </Layout>
+    <div className="main home-main">
+      <Hero title="404 Not Found">
+        What you are looking for is either no longer here or has moved.
+      </Hero>
+    </div>
   );
 };
 

--- a/site/src/pages/contribute/index.js
+++ b/site/src/pages/contribute/index.js
@@ -1,41 +1,38 @@
 import React from 'react';
 import { Link, graphql } from 'gatsby';
 
-import Layout from '../../components/layout';
 import PageHead from '../../components/page-head';
 
 import ContributeHero from '../../../content/contribute-hero';
 
-const ContributeIndex = ({ data, location }) => {
+const ContributeIndex = ({ data }) => {
   const docs = data.allMdx.nodes;
 
   return (
-    <Layout data={data} location={location}>
-      <div className="main docs-main">
-        <ContributeHero />
-        {docs.map((node, index) => {
-          const title = node.frontmatter.title;
-          const toc = node.tableOfContents.items;
-          return (
-            <article className="content" key={`${node.fields.slug}-${index}`}>
-              <h3>
-                <Link to={node.fields.slug}>{title}</Link>
-              </h3>
-              <ul>
-                {toc &&
-                  toc.map((item, i) => (
-                    <li key={i}>
-                      <Link to={`${node.fields.slug}${item.url}`}>
-                        {item.title}
-                      </Link>
-                    </li>
-                  ))}
-              </ul>
-            </article>
-          );
-        })}
-      </div>
-    </Layout>
+    <div className="main docs-main">
+      <ContributeHero />
+      {docs.map((node, index) => {
+        const title = node.frontmatter.title;
+        const toc = node.tableOfContents.items;
+        return (
+          <article className="content" key={`${node.fields.slug}-${index}`}>
+            <h3>
+              <Link to={node.fields.slug}>{title}</Link>
+            </h3>
+            <ul>
+              {toc &&
+                toc.map((item, i) => (
+                  <li key={i}>
+                    <Link to={`${node.fields.slug}${item.url}`}>
+                      {item.title}
+                    </Link>
+                  </li>
+                ))}
+            </ul>
+          </article>
+        );
+      })}
+    </div>
   );
 };
 

--- a/site/src/pages/index.js
+++ b/site/src/pages/index.js
@@ -5,20 +5,17 @@ import FeaturedProjects from '../../content/featured-projects.mdx';
 import HeroContent from '../../content/hero.mdx';
 import Partnerships from '../../content/partnerships.mdx';
 
-import Layout from '../components/layout';
 import PageHead from '../components/page-head';
 
-const SiteIndex = ({ data, location }) => {
+const SiteIndex = () => {
   return (
-    <Layout data={data} location={location}>
-      <div className="main home-main">
-        <HeroContent />
-        <section className="content">
-          <FeaturedProjects />
-          <Partnerships />
-        </section>
-      </div>
-    </Layout>
+    <div className="main home-main">
+      <HeroContent />
+      <section className="content">
+        <FeaturedProjects />
+        <Partnerships />
+      </section>
+    </div>
   );
 };
 

--- a/site/src/styles/header.css
+++ b/site/src/styles/header.css
@@ -26,15 +26,11 @@
   list-style-type: none;
   margin: 0 1rem;
   padding: 0 0 10px 0;
-  border-bottom: 5px solid var(--white-foundational-color);
-}
-
-.header-nav ul li.nav-link-current,
-.header-nav ul li:hover {
-  border-bottom: 5px solid var(--primary-foundational-color);
 }
 
 .header-nav ul li a {
+  position: relative;
+  display: inline-block;
   font-weight: 600;
   font-size: 20px;
   color: var(--black-foundational-color);
@@ -42,6 +38,29 @@
 
 .header-nav ul li a:hover {
   text-decoration: none;
+}
+
+/* Thin blue nav indicator. Hover and the persistent active state both
+   target the same scaleX(1) value, so clicking an item you're already
+   hovering causes no transition at all (the value doesn't change) —
+   only an item that loses both hover and active retracts (scaleX(1)->0,
+   transform-origin: left, i.e. right-to-left). */
+.header-nav ul li a::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -10px;
+  height: 4px;
+  background-color: var(--primary-foundational-color);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 260ms ease-out;
+}
+
+.header-nav ul li a:hover::after,
+.header-nav ul li.nav-link-current a::after {
+  transform: scaleX(1);
 }
 
 .header-nav ul li:last-of-type {

--- a/site/src/templates/contribute.js
+++ b/site/src/templates/contribute.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Link, graphql } from 'gatsby';
 
-import Layout from '../components/layout';
 import PageHead from '../components/page-head';
 
 const ContributeTemplate = ({ children, data, pageContext, location }) => {
@@ -11,7 +10,7 @@ const ContributeTemplate = ({ children, data, pageContext, location }) => {
   const siteTitle = data.site?.siteMetadata?.title;
 
   return (
-    <Layout data={data} location={location}>
+    <>
       <article className="page-main content">
         <h3>{siteTitle}</h3>
       </article>
@@ -49,7 +48,7 @@ const ContributeTemplate = ({ children, data, pageContext, location }) => {
           {children}
         </div>
       </article>
-    </Layout>
+    </>
   );
 };
 

--- a/site/src/templates/documentation.js
+++ b/site/src/templates/documentation.js
@@ -2,7 +2,6 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { Link, navigate, graphql } from 'gatsby';
 import { Box } from '@mui/material';
 
-import Layout from '../components/layout';
 import PageHead from '../components/page-head';
 import VersionSelect from '../components/version-select';
 import { getCurrentVersion, getDocsVersion } from '../utils/version-docs';
@@ -33,7 +32,7 @@ const DocumentationTemplate = ({ children, data, pageContext, location }) => {
   );
 
   return (
-    <Layout data={data} location={location}>
+    <>
       <article className="page-main content">
         <h3>{siteTitle}</h3>
       </article>
@@ -78,7 +77,7 @@ const DocumentationTemplate = ({ children, data, pageContext, location }) => {
           {children}
         </div>
       </article>
-    </Layout>
+    </>
   );
 };
 

--- a/site/src/templates/page.js
+++ b/site/src/templates/page.js
@@ -1,19 +1,16 @@
 import React from 'react';
 import { graphql } from 'gatsby';
 
-import Layout from '../components/layout';
 import PageHead from '../components/page-head';
 
-const PageTemplate = ({ title, data, location, children }) => {
+const PageTemplate = ({ title, children }) => {
   return (
-    <Layout data={data} location={location}>
-      <article className="page-main content">
-        <header>
-          <h2>{title}</h2>
-        </header>
-        {children}
-      </article>
-    </Layout>
+    <article className="page-main content">
+      <header>
+        <h2>{title}</h2>
+      </header>
+      {children}
+    </article>
   );
 };
 


### PR DESCRIPTION
Fixes [#142](https://github.com/morganstanley/morganstanley.github.io/issues/142)

The Home/Contribute active-route check used a substring match against "/", which matched every route, so the previous nav item's underline never cleared when navigating. 

Layout is now mounted once via Gatsby's wrapPageElement instead of per-page, so the active-item underline can transition smoothly between routes via CSS instead of popping instantly.

How the fix makes it look now (See the underline in the navbar) : 

https://github.com/user-attachments/assets/f8a888df-90e0-4533-9203-81fe01db07ad

Reference used: [https://www.morganstanley.com/#mobileNav](https://www.morganstanley.com/#mobileNav)